### PR TITLE
23cst7/yuriy magus/lab1

### DIFF
--- a/clang/examples/AnnotateUnusedVars/AnnotateUnusedVars.cpp
+++ b/clang/examples/AnnotateUnusedVars/AnnotateUnusedVars.cpp
@@ -1,0 +1,98 @@
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Basic/Diagnostic.h"
+
+using namespace clang;
+
+namespace {
+
+class AnnotateUnusedVarsVisitor : public RecursiveASTVisitor<AnnotateUnusedVarsVisitor> {
+public:
+  explicit AnnotateUnusedVarsVisitor(ASTContext &Context, DiagnosticsEngine &Diags)
+      : Context(Context), Diags(Diags) {
+    DiagID = Diags.getCustomDiagID(
+      DiagnosticsEngine::Warning,
+      "variable '%0' is unused; annotating with [[maybe_unused]]"
+    );
+  }
+
+bool VisitVarDecl(VarDecl *VD) {
+    if (!VD || VD->isImplicit())
+      return true;
+
+    bool IsLocal = VD->isLocalVarDecl();
+    bool IsParm = isa<ParmVarDecl>(VD);
+    if (!IsLocal && !IsParm)
+      return true;
+
+    const DeclContext *DC = VD->getDeclContext();
+    if (!DC || !DC->isFunctionOrMethod())
+      return true;
+
+    SourceLocation Loc = VD->getLocation();
+    SourceManager &SM = Context.getSourceManager();
+    if (Loc.isInvalid() || SM.isInSystemHeader(Loc) || SM.isInSystemMacro(Loc))
+      return true;
+
+    if (VD->hasAttr<UnusedAttr>() || VD->isUsed() || VD->isReferenced())
+      return true;
+
+    auto *Attr = UnusedAttr::CreateImplicit(Context, Loc, UnusedAttr::CXX11_maybe_unused);
+    VD->addAttr(Attr);
+
+    Diags.Report(Loc, DiagID) << VD->getNameAsString();
+
+    return true;
+  }
+
+private:
+  ASTContext &Context;
+  DiagnosticsEngine &Diags;
+  unsigned DiagID;
+};
+
+class AnnotateUnusedVarsConsumer : public ASTConsumer {
+public:
+  explicit AnnotateUnusedVarsConsumer(ASTContext &Context, DiagnosticsEngine &Diags)
+      : Visitor(Context, Diags) {}
+
+  void HandleTranslationUnit(ASTContext &Context) override {
+    Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+  }
+
+private:
+  AnnotateUnusedVarsVisitor Visitor;
+};
+
+class AnnotateUnusedVarsAction : public PluginASTAction {
+protected:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(
+    CompilerInstance &CI,
+    llvm::StringRef
+  ) override {
+    return std::make_unique<AnnotateUnusedVarsConsumer>(
+      CI.getASTContext(),
+      CI.getDiagnostics()
+    );
+  }
+
+  bool ParseArgs(
+    const CompilerInstance &CI,
+    const std::vector<std::string> &Args
+  ) override {
+    return true;
+  }
+
+  ActionType getActionType() override {
+    return AddBeforeMainAction;
+  }
+};
+
+} // namespace
+
+static FrontendPluginRegistry::Add<AnnotateUnusedVarsAction>
+    X("annotate-unused-vars", "Annotates unused locals with [[maybe_unused]]");

--- a/clang/examples/AnnotateUnusedVars/CMakeLists.txt
+++ b/clang/examples/AnnotateUnusedVars/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_llvm_library(AnnotateUnusedVars MODULE 
+  AnnotateUnusedVars.cpp 
+  PLUGIN_TOOL clang
+)
+
+set(ANNOTATE_UNUSED_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+set(ANNOTATE_UNUSED_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tests)
+
+file(MAKE_DIRECTORY ${ANNOTATE_UNUSED_BINARY_DIR})
+
+configure_file(
+  ${ANNOTATE_UNUSED_SOURCE_DIR}/lit.site.cfg.py.in
+  ${ANNOTATE_UNUSED_BINARY_DIR}/lit.site.cfg.py
+  @ONLY
+)
+
+add_custom_target(check-annotate-unused
+  COMMAND ${PYTHON_EXECUTABLE} ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py -v ${ANNOTATE_UNUSED_BINARY_DIR}
+  DEPENDS AnnotateUnusedVars clang FileCheck
+  COMMENT "Running AnnotateUnusedVars tests from subfolder..."
+)

--- a/clang/examples/AnnotateUnusedVars/tests/lit.site.cfg.py.in
+++ b/clang/examples/AnnotateUnusedVars/tests/lit.site.cfg.py.in
@@ -1,0 +1,21 @@
+import lit.formats
+import os
+
+config.name = 'ClangAnnotateUnusedVars'
+config.test_format = lit.formats.ShTest(True)
+config.suffixes = ['.cpp']
+
+config.clang_bin = r"@LLVM_BINARY_DIR@/bin/clang"
+config.plugin_path = r"@LLVM_LIBRARY_OUTPUT_INTDIR@/AnnotateUnusedVars.so"
+config.filecheck_bin = r"@LLVM_BINARY_DIR@/bin/FileCheck"
+
+config.test_source_root = r"@ANNOTATE_UNUSED_SOURCE_DIR@"
+config.test_exec_root = r"@ANNOTATE_UNUSED_BINARY_DIR@"
+
+config.substitutions.append(('%clang_cc1', f"{config.clang_bin} -cc1"))
+config.substitutions.append(('%plugin_path', config.plugin_path))
+
+config.environment['PATH'] = os.path.pathsep.join([
+    os.path.dirname(config.filecheck_bin), 
+    config.environment.get('PATH', '')
+])

--- a/clang/examples/AnnotateUnusedVars/tests/testLambdas.cpp
+++ b/clang/examples/AnnotateUnusedVars/tests/testLambdas.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++17 -load %plugin_path -add-plugin annotate-unused-vars -ast-dump %s | FileCheck %s
+
+void lambda_test() {
+    int captured_var = 10;
+    
+    auto my_lambda = [captured_var](int lambda_param) {
+        int inner_unused = captured_var + 1;
+    };
+}
+
+// CHECK: FunctionDecl{{.*}} lambda_test
+
+// CHECK: VarDecl{{.*}} captured_var 'int'
+// CHECK-NOT: UnusedAttr
+
+// CHECK: VarDecl{{.*}} my_lambda
+
+// CHECK: ParmVarDecl{{.*}} lambda_param 'int'
+// CHECK: UnusedAttr
+
+// CHECK: VarDecl{{.*}} inner_unused 'int'
+// CHECK: UnusedAttr
+
+// CHECK: UnusedAttr

--- a/clang/examples/AnnotateUnusedVars/tests/testScopesAndUnevaluated.cpp
+++ b/clang/examples/AnnotateUnusedVars/tests/testScopesAndUnevaluated.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -std=c++17 -load %plugin_path -add-plugin annotate-unused-vars -ast-dump %s | FileCheck %s
+
+int global_var = 100;
+
+void scope_test() {
+    static int static_unused = 200;
+    int used_in_sizeof = 300;
+    unsigned long size_result = sizeof(used_in_sizeof);
+}
+
+// CHECK: VarDecl{{.*}} global_var 'int'
+// CHECK-NOT: UnusedAttr
+
+// CHECK: FunctionDecl{{.*}} scope_test
+
+// CHECK: VarDecl{{.*}} static_unused 'int'
+// CHECK: UnusedAttr
+
+// CHECK: VarDecl{{.*}} used_in_sizeof 'int'
+// CHECK-NOT: UnusedAttr
+
+// CHECK: VarDecl{{.*}} size_result 'unsigned long'
+// CHECK: UnusedAttr

--- a/clang/examples/AnnotateUnusedVars/tests/testUnusedVars.cpp
+++ b/clang/examples/AnnotateUnusedVars/tests/testUnusedVars.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -std=c++17 -load %plugin_path -add-plugin annotate-unused-vars -ast-dump %s | FileCheck %s
+
+int foo(int a, int b, int c) {
+    int used_local = a + b;
+    int unused_local = 42;
+    return used_local;
+  }
+  
+  // CHECK: FunctionDecl {{.*}} foo
+  // CHECK: ParmVarDecl{{.*}} a 'int'
+  // CHECK-NOT: UnusedAttr
+  // CHECK: ParmVarDecl{{.*}} b 'int'
+  // CHECK-NOT: UnusedAttr
+  // CHECK: ParmVarDecl{{.*}} c 'int'
+  // CHECK-NEXT: UnusedAttr
+  
+  // CHECK: VarDecl{{.*}} used_local 'int'
+  // CHECK-NOT: UnusedAttr
+  // CHECK: VarDecl{{.*}} unused_local 'int'
+  // CHECK: UnusedAttr
+  
+  // Проверка, что уже помеченные переменные не трогаем.
+  int bar([[maybe_unused]] int x, int y) {
+    [[maybe_unused]] int already_marked = 0;
+    int should_be_marked = 0;
+    (void)y;
+    return 0;
+  }
+  
+  // CHECK: FunctionDecl {{.*}} bar
+  // CHECK: ParmVarDecl{{.*}} x 'int'
+  // CHECK-NEXT: UnusedAttr
+  // CHECK: ParmVarDecl{{.*}} y 'int'
+  // CHECK-NOT: UnusedAttr
+  //
+  // CHECK: VarDecl{{.*}} already_marked 'int'
+  // CHECK: UnusedAttr
+  // CHECK: VarDecl{{.*}} should_be_marked 'int'
+  // CHECK: UnusedAttr

--- a/clang/examples/CMakeLists.txt
+++ b/clang/examples/CMakeLists.txt
@@ -4,6 +4,7 @@ if(NOT CLANG_BUILD_EXAMPLES)
 endif()
 
 if(CLANG_PLUGIN_SUPPORT)
+  add_subdirectory(AnnotateUnusedVars)
   add_subdirectory(LLVMPrintFunctionNames)
   add_subdirectory(PrintFunctionNames)
   add_subdirectory(AnnotateFunctions)

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -85,6 +85,23 @@
       "cacheVariables": {
         "LLVM_USE_SANITIZER": "Address"
       }
+    },
+    {
+      "name": "wsl-clang-release",
+      "displayName": "WSL: Clang Release",
+      "description": "Сборка для WSL 2 (Release)",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build-wsl-release", 
+      "cacheVariables": {
+        "LLVM_ENABLE_PROJECTS": "clang",
+        "CLANG_BUILD_EXAMPLES": true,
+        "LLVM_ENABLE_PLUGINS": true,
+        "CLANG_PLUGIN_SUPPORT": true,
+        "LLVM_EXPORT_SYMBOLS_FOR_PLUGINS": true,
+        "CMAKE_BUILD_TYPE": "Release",
+        "LLVM_TARGETS_TO_BUILD": "X86",
+        "LLVM_ENABLE_ASSERTIONS": true
+      }
     }
   ]
 }


### PR DESCRIPTION
Данный плагин выполняет статический анализ AST-дерева, находит неиспользуемые локальные переменные и параметры функций, после чего автоматически аннотирует их атрибутом `[[maybe_unused]]`.

### Предварительные условия

* Исходный код LLVM/Clang успешно сконфигурирован в системе.
* Плагин зарегистрирован в системе сборки под именем `AnnotateUnusedVars`.

### Порядок запуска

1. **Переход в директорию сборки:**
Зайдите в папку, где выполнялась компиляция LLVM (например, `build`):
```bash
cd /путь/к/llvm-project/build

```


2. **Сборка плагина:**
Скомпилируйте библиотеку плагина отдельно. Использование флага `-j 2` ограничивает количество потоков для стабильности на слабых узлах:
```bash
ninja AnnotateUnusedVars -j 2

```


3. **Запуск автоматизированных тестов:**
Для проверки корректности работы плагина на различных сценариях (лямбды, области видимости, невычисляемые контексты) запустите встроенную цель тестирования:
```bash
ninja -j 2 check-annotate-unused

```

**Результат успешного выполнения:**
`Total Discovered Tests: 3`
`Passed: 3 (100.00%)`

<img width="1285" height="252" alt="image" src="https://github.com/user-attachments/assets/9020069f-d0f6-4f4d-a070-c18546f40734" />
