### PR TITLE
23cst7/yuriy magus/lab2

### DIFF
--- a/clang/examples/AnnotateUnusedVars/AnnotateUnusedVars.cpp
+++ b/clang/examples/AnnotateUnusedVars/AnnotateUnusedVars.cpp
@@ -1,0 +1,98 @@
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Basic/Diagnostic.h"
+
+using namespace clang;
+
+namespace {
+
+class AnnotateUnusedVarsVisitor : public RecursiveASTVisitor<AnnotateUnusedVarsVisitor> {
+public:
+  explicit AnnotateUnusedVarsVisitor(ASTContext &Context, DiagnosticsEngine &Diags)
+      : Context(Context), Diags(Diags) {
+    DiagID = Diags.getCustomDiagID(
+      DiagnosticsEngine::Warning,
+      "variable '%0' is unused; annotating with [[maybe_unused]]"
+    );
+  }
+
+bool VisitVarDecl(VarDecl *VD) {
+    if (!VD || VD->isImplicit())
+      return true;
+
+    bool IsLocal = VD->isLocalVarDecl();
+    bool IsParm = isa<ParmVarDecl>(VD);
+    if (!IsLocal && !IsParm)
+      return true;
+
+    const DeclContext *DC = VD->getDeclContext();
+    if (!DC || !DC->isFunctionOrMethod())
+      return true;
+
+    SourceLocation Loc = VD->getLocation();
+    SourceManager &SM = Context.getSourceManager();
+    if (Loc.isInvalid() || SM.isInSystemHeader(Loc) || SM.isInSystemMacro(Loc))
+      return true;
+
+    if (VD->hasAttr<UnusedAttr>() || VD->isUsed() || VD->isReferenced())
+      return true;
+
+    auto *Attr = UnusedAttr::CreateImplicit(Context, Loc, UnusedAttr::CXX11_maybe_unused);
+    VD->addAttr(Attr);
+
+    Diags.Report(Loc, DiagID) << VD->getNameAsString();
+
+    return true;
+  }
+
+private:
+  ASTContext &Context;
+  DiagnosticsEngine &Diags;
+  unsigned DiagID;
+};
+
+class AnnotateUnusedVarsConsumer : public ASTConsumer {
+public:
+  explicit AnnotateUnusedVarsConsumer(ASTContext &Context, DiagnosticsEngine &Diags)
+      : Visitor(Context, Diags) {}
+
+  void HandleTranslationUnit(ASTContext &Context) override {
+    Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+  }
+
+private:
+  AnnotateUnusedVarsVisitor Visitor;
+};
+
+class AnnotateUnusedVarsAction : public PluginASTAction {
+protected:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(
+    CompilerInstance &CI,
+    llvm::StringRef
+  ) override {
+    return std::make_unique<AnnotateUnusedVarsConsumer>(
+      CI.getASTContext(),
+      CI.getDiagnostics()
+    );
+  }
+
+  bool ParseArgs(
+    const CompilerInstance &CI,
+    const std::vector<std::string> &Args
+  ) override {
+    return true;
+  }
+
+  ActionType getActionType() override {
+    return AddBeforeMainAction;
+  }
+};
+
+} // namespace
+
+static FrontendPluginRegistry::Add<AnnotateUnusedVarsAction>
+    X("annotate-unused-vars", "Annotates unused locals with [[maybe_unused]]");

--- a/clang/examples/AnnotateUnusedVars/CMakeLists.txt
+++ b/clang/examples/AnnotateUnusedVars/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_llvm_library(AnnotateUnusedVars MODULE 
+  AnnotateUnusedVars.cpp 
+  PLUGIN_TOOL clang
+)
+
+set(ANNOTATE_UNUSED_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+set(ANNOTATE_UNUSED_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tests)
+
+file(MAKE_DIRECTORY ${ANNOTATE_UNUSED_BINARY_DIR})
+
+configure_file(
+  ${ANNOTATE_UNUSED_SOURCE_DIR}/lit.site.cfg.py.in
+  ${ANNOTATE_UNUSED_BINARY_DIR}/lit.site.cfg.py
+  @ONLY
+)
+
+add_custom_target(check-annotate-unused
+  COMMAND ${PYTHON_EXECUTABLE} ${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py -v ${ANNOTATE_UNUSED_BINARY_DIR}
+  DEPENDS AnnotateUnusedVars clang FileCheck
+  COMMENT "Running AnnotateUnusedVars tests from subfolder..."
+)

--- a/clang/examples/AnnotateUnusedVars/tests/lit.site.cfg.py.in
+++ b/clang/examples/AnnotateUnusedVars/tests/lit.site.cfg.py.in
@@ -1,0 +1,21 @@
+import lit.formats
+import os
+
+config.name = 'ClangAnnotateUnusedVars'
+config.test_format = lit.formats.ShTest(True)
+config.suffixes = ['.cpp']
+
+config.clang_bin = r"@LLVM_BINARY_DIR@/bin/clang"
+config.plugin_path = r"@LLVM_LIBRARY_OUTPUT_INTDIR@/AnnotateUnusedVars.so"
+config.filecheck_bin = r"@LLVM_BINARY_DIR@/bin/FileCheck"
+
+config.test_source_root = r"@ANNOTATE_UNUSED_SOURCE_DIR@"
+config.test_exec_root = r"@ANNOTATE_UNUSED_BINARY_DIR@"
+
+config.substitutions.append(('%clang_cc1', f"{config.clang_bin} -cc1"))
+config.substitutions.append(('%plugin_path', config.plugin_path))
+
+config.environment['PATH'] = os.path.pathsep.join([
+    os.path.dirname(config.filecheck_bin), 
+    config.environment.get('PATH', '')
+])

--- a/clang/examples/AnnotateUnusedVars/tests/testLambdas.cpp
+++ b/clang/examples/AnnotateUnusedVars/tests/testLambdas.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -std=c++17 -load %plugin_path -add-plugin annotate-unused-vars -ast-dump %s | FileCheck %s
+
+void lambda_test() {
+    int captured_var = 10;
+    
+    auto my_lambda = [captured_var](int lambda_param) {
+        int inner_unused = captured_var + 1;
+    };
+}
+
+// CHECK: FunctionDecl{{.*}} lambda_test
+
+// CHECK: VarDecl{{.*}} captured_var 'int'
+// CHECK-NOT: UnusedAttr
+
+// CHECK: VarDecl{{.*}} my_lambda
+
+// CHECK: ParmVarDecl{{.*}} lambda_param 'int'
+// CHECK: UnusedAttr
+
+// CHECK: VarDecl{{.*}} inner_unused 'int'
+// CHECK: UnusedAttr
+
+// CHECK: UnusedAttr

--- a/clang/examples/AnnotateUnusedVars/tests/testScopesAndUnevaluated.cpp
+++ b/clang/examples/AnnotateUnusedVars/tests/testScopesAndUnevaluated.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -std=c++17 -load %plugin_path -add-plugin annotate-unused-vars -ast-dump %s | FileCheck %s
+
+int global_var = 100;
+
+void scope_test() {
+    static int static_unused = 200;
+    int used_in_sizeof = 300;
+    unsigned long size_result = sizeof(used_in_sizeof);
+}
+
+// CHECK: VarDecl{{.*}} global_var 'int'
+// CHECK-NOT: UnusedAttr
+
+// CHECK: FunctionDecl{{.*}} scope_test
+
+// CHECK: VarDecl{{.*}} static_unused 'int'
+// CHECK: UnusedAttr
+
+// CHECK: VarDecl{{.*}} used_in_sizeof 'int'
+// CHECK-NOT: UnusedAttr
+
+// CHECK: VarDecl{{.*}} size_result 'unsigned long'
+// CHECK: UnusedAttr

--- a/clang/examples/AnnotateUnusedVars/tests/testUnusedVars.cpp
+++ b/clang/examples/AnnotateUnusedVars/tests/testUnusedVars.cpp
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -std=c++17 -load %plugin_path -add-plugin annotate-unused-vars -ast-dump %s | FileCheck %s
+
+int foo(int a, int b, int c) {
+    int used_local = a + b;
+    int unused_local = 42;
+    return used_local;
+  }
+  
+  // CHECK: FunctionDecl {{.*}} foo
+  // CHECK: ParmVarDecl{{.*}} a 'int'
+  // CHECK-NOT: UnusedAttr
+  // CHECK: ParmVarDecl{{.*}} b 'int'
+  // CHECK-NOT: UnusedAttr
+  // CHECK: ParmVarDecl{{.*}} c 'int'
+  // CHECK-NEXT: UnusedAttr
+  
+  // CHECK: VarDecl{{.*}} used_local 'int'
+  // CHECK-NOT: UnusedAttr
+  // CHECK: VarDecl{{.*}} unused_local 'int'
+  // CHECK: UnusedAttr
+  
+  // Проверка, что уже помеченные переменные не трогаем.
+  int bar([[maybe_unused]] int x, int y) {
+    [[maybe_unused]] int already_marked = 0;
+    int should_be_marked = 0;
+    (void)y;
+    return 0;
+  }
+  
+  // CHECK: FunctionDecl {{.*}} bar
+  // CHECK: ParmVarDecl{{.*}} x 'int'
+  // CHECK-NEXT: UnusedAttr
+  // CHECK: ParmVarDecl{{.*}} y 'int'
+  // CHECK-NOT: UnusedAttr
+  //
+  // CHECK: VarDecl{{.*}} already_marked 'int'
+  // CHECK: UnusedAttr
+  // CHECK: VarDecl{{.*}} should_be_marked 'int'
+  // CHECK: UnusedAttr

--- a/clang/examples/CMakeLists.txt
+++ b/clang/examples/CMakeLists.txt
@@ -4,6 +4,7 @@ if(NOT CLANG_BUILD_EXAMPLES)
 endif()
 
 if(CLANG_PLUGIN_SUPPORT)
+  add_subdirectory(AnnotateUnusedVars)
   add_subdirectory(LLVMPrintFunctionNames)
   add_subdirectory(PrintFunctionNames)
   add_subdirectory(AnnotateFunctions)

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -85,6 +85,23 @@
       "cacheVariables": {
         "LLVM_USE_SANITIZER": "Address"
       }
+    },
+    {
+      "name": "wsl-clang-release",
+      "displayName": "WSL: Clang Release",
+      "description": "Сборка для WSL 2 (Release)",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build-wsl-release", 
+      "cacheVariables": {
+        "LLVM_ENABLE_PROJECTS": "clang",
+        "CLANG_BUILD_EXAMPLES": true,
+        "LLVM_ENABLE_PLUGINS": true,
+        "CLANG_PLUGIN_SUPPORT": true,
+        "LLVM_EXPORT_SYMBOLS_FOR_PLUGINS": true,
+        "CMAKE_BUILD_TYPE": "Release",
+        "LLVM_TARGETS_TO_BUILD": "X86",
+        "LLVM_ENABLE_ASSERTIONS": true
+      }
     }
   ]
 }

--- a/llvm/include/llvm/Transforms/Utils/SimpleInliner.h
+++ b/llvm/include/llvm/Transforms/Utils/SimpleInliner.h
@@ -1,0 +1,15 @@
+#ifndef LLVM_TRANSFORMS_UTILS_TEST2_H
+#define LLVM_TRANSFORMS_UTILS_TEST2_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class SimpleInlinerPass : public PassInfoMixin<SimpleInlinerPass> {
+public:
+  PreservedAnalyses run(Function& F, FunctionAnalysisManager& AM);
+};
+
+} // namespace llvm
+
+#endif // LLVM_TRANSFORMS_UTILS_TEST2_H

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -371,6 +371,7 @@
 #include "llvm/Transforms/Utils/PredicateInfo.h"
 #include "llvm/Transforms/Utils/ProfileVerify.h"
 #include "llvm/Transforms/Utils/RelLookupTableConverter.h"
+#include "llvm/Transforms/Utils/SimpleInliner.h"
 #include "llvm/Transforms/Utils/StripGCRelocates.h"
 #include "llvm/Transforms/Utils/StripNonLineTableDebugInfo.h"
 #include "llvm/Transforms/Utils/SymbolRewriter.h"

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -538,6 +538,7 @@ FUNCTION_PASS("sccp", SCCPPass())
 FUNCTION_PASS("select-optimize", SelectOptimizePass(*TM))
 FUNCTION_PASS("separate-const-offset-from-gep",
               SeparateConstOffsetFromGEPPass())
+FUNCTION_PASS("simple-inliner", SimpleInlinerPass())
 FUNCTION_PASS("sink", SinkingPass())
 FUNCTION_PASS("sjlj-eh-prepare", SjLjEHPreparePass(TM))
 FUNCTION_PASS("slp-vectorizer", SLPVectorizerPass())

--- a/llvm/lib/Transforms/Utils/CMakeLists.txt
+++ b/llvm/lib/Transforms/Utils/CMakeLists.txt
@@ -80,6 +80,7 @@ add_llvm_component_library(LLVMTransformUtils
   SampleProfileInference.cpp
   SampleProfileLoaderBaseUtil.cpp
   SanitizerStats.cpp
+  SimpleInliner.cpp
   SimplifyCFG.cpp
   SimplifyIndVar.cpp
   SimplifyLibCalls.cpp

--- a/llvm/lib/Transforms/Utils/SimpleInliner.cpp
+++ b/llvm/lib/Transforms/Utils/SimpleInliner.cpp
@@ -1,0 +1,61 @@
+#include "llvm/Transforms/Utils/SimpleInliner.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/ValueMapper.h"
+#include <vector>
+
+using namespace llvm;
+
+PreservedAnalyses SimpleInlinerPass::run(Function& F, FunctionAnalysisManager& AM) {
+  bool Changed = false;
+  std::vector<CallInst*> CallsToInline;
+
+  for (BasicBlock& BB : F) {
+    for (Instruction& I : BB) {
+      if (auto* CI = dyn_cast<CallInst>(&I)) {
+        Function* Callee = CI->getCalledFunction();
+        if (Callee && !Callee->isDeclaration() &&
+            Callee->getReturnType()->isVoidTy() && 
+            Callee->arg_size() == 0) {
+          CallsToInline.push_back(CI);
+        }
+      }
+    }
+  }
+
+  for (CallInst* CI : CallsToInline) {
+    Function* Callee = CI->getCalledFunction();
+    BasicBlock* CallBlock = CI->getParent();
+    
+    BasicBlock* PostCallBlock = CallBlock->splitBasicBlock(CI->getIterator(), "post.call");
+
+    ValueToValueMapTy VMap;
+    std::vector<BasicBlock*> ClonedBlocks;
+
+    for (BasicBlock& BB : *Callee) {
+      BasicBlock* CBB = CloneBasicBlock(&BB, VMap, "cloned", &F);
+      VMap[&BB] = CBB;
+      ClonedBlocks.push_back(CBB);
+    }
+
+    for (BasicBlock* CBB : ClonedBlocks) {
+      for (Instruction& I : *CBB) {
+        RemapInstruction(&I, VMap, RF_NoModuleLevelChanges | RF_IgnoreMissingLocals);
+      }
+      
+      if (ReturnInst* RI = dyn_cast<ReturnInst>(CBB->getTerminator())) {
+        BranchInst::Create(PostCallBlock, CBB);
+        RI->eraseFromParent();
+      }
+    }
+
+    CallBlock->getTerminator()->eraseFromParent();
+    BranchInst::Create(ClonedBlocks[0], CallBlock);
+
+    CI->eraseFromParent();
+    Changed = true;
+  }
+
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm/test/Transforms/Util/inlining-multi-block.ll‎
+++ b/llvm/test/Transforms/Util/inlining-multi-block.ll‎
@@ -1,0 +1,37 @@
+; RUN: opt -passes=simple-inliner -S < %s | FileCheck %s
+
+declare void @foo()
+declare void @bar()
+
+define void @callee_with_cfg() {
+entry:
+  br i1 undef, label %left, label %right
+left:
+  call void @foo()
+  ret void
+right:
+  call void @bar()
+  ret void
+}
+
+define void @caller() {
+; CHECK-LABEL: define void @caller()
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   br label %entrycloned
+
+; CHECK: post.call:
+; CHECK-NEXT:   ret void
+
+; CHECK: entrycloned:
+; CHECK-NEXT:   br i1 undef, label %leftcloned, label %rightcloned
+; CHECK: leftcloned:
+; CHECK-NEXT:   call void @foo()
+; CHECK-NEXT:   br label %post.call
+; CHECK: rightcloned:
+; CHECK-NEXT:   call void @bar()
+; CHECK-NEXT:   br label %post.call
+
+entry:
+  call void @callee_with_cfg()
+  ret void
+}

--- a/llvm/test/Transforms/Util/simple-inliner.ll
+++ b/llvm/test/Transforms/Util/simple-inliner.ll
@@ -1,0 +1,26 @@
+; RUN: opt -passes=simple-inliner -S < %s | FileCheck %s
+
+define void @dummy_callee() {
+entry:
+  call void @do_something()
+  ret void
+}
+
+declare void @do_something()
+
+define void @caller() {
+; CHECK-LABEL: define void @caller()
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   br label %entrycloned
+
+; CHECK: post.call:
+; CHECK-NEXT:   ret void
+
+; CHECK: entrycloned:
+; CHECK-NEXT:   call void @do_something()
+; CHECK-NEXT:   br label %post.call
+
+entry:
+  call void @dummy_callee()
+  ret void
+}

--- a/llvm/test/Transforms/Util/skip-declaration.ll
+++ b/llvm/test/Transforms/Util/skip-declaration.ll
@@ -1,0 +1,13 @@
+; RUN: opt -passes=simple-inliner -S < %s | FileCheck %s
+
+declare void @external_func()
+
+define void @caller() {
+; CHECK-LABEL: define void @caller
+; CHECK: entry:
+; CHECK-NEXT: call void @external_func()
+; CHECK-NEXT: ret void
+entry:
+  call void @external_func()
+  ret void
+}

--- a/llvm/test/Transforms/Util/skip-non-void.ll
+++ b/llvm/test/Transforms/Util/skip-non-void.ll
@@ -1,0 +1,16 @@
+; RUN: opt -passes=simple-inliner -S < %s | FileCheck %s
+
+define i32 @callee_returns_int() {
+entry:
+  ret i32 42
+}
+
+define void @caller() {
+; CHECK-LABEL: define void @caller
+; CHECK: entry:
+; CHECK-NEXT: %res = call i32 @callee_returns_int()
+; CHECK-NEXT: ret void
+entry:
+  %res = call i32 @callee_returns_int()
+  ret void
+}

--- a/llvm/test/Transforms/Util/skip-with-args.ll‎
+++ b/llvm/test/Transforms/Util/skip-with-args.ll‎
@@ -1,0 +1,16 @@
+; RUN: opt -passes=simple-inliner -S < %s | FileCheck %s
+
+define void @callee_with_args(i32 %a) {
+entry:
+  ret void
+}
+
+define void @caller(i32 %val) {
+; CHECK-LABEL: define void @caller
+; CHECK: entry:
+; CHECK-NEXT: call void @callee_with_args(i32 %val)
+; CHECK-NEXT: ret void
+entry:
+  call void @callee_with_args(i32 %val)
+  ret void
+}


### PR DESCRIPTION
В рамках работы реализован функциональный проход (**SimpleInlinerPass**), который выполняет встраивание (inlining) функций без использования стандартного `llvm::InlineFunction`. Проход анализирует вызовы (`CallInst`) и переносит тело вызываемой функции напрямую в вызывающую, модифицируя граф потока управления (CFG).

**Критерии встраивания:**

* Функция не является внешним объявлением (имеет тело).
* Функция не принимает аргументов (`arg_size == 0`).
* Функция возвращает тип `void`.

### Инструкция по сборке и запуску

#### 1. Компиляция пасса

Для сборки обновленного инструмента `opt` с интегрированным пассом выполните в папке `build`:

```bash
ninja -j 2 opt

```

#### 2. Тестирование

Для проверки корректности работы реализовано 5 тестовых сценариев, покрывающих как успешное встраивание, так и фильтрацию неподходящих функций.

Запуск тестов осуществляется через утилиту `lit`. Выполните команду из корневой директории сборки:

```bash
python3 bin/llvm-lit -v \
  test/Transforms/Util/simple-inliner.ll \
  test/Transforms/Util/inlining-multi-block.ll \
  test/Transforms/Util/skip-with-args.ll \
  test/Transforms/Util/skip-non-void.ll \
  test/Transforms/Util/skip-declaration.ll

```

### Описание тестовых случаев

| Файл теста | Описание проверки |
| --- | --- |
| `simple-inliner.ll` | Базовый сценарий встраивания простой void-функции. |
| `inlining-multi-block.ll` | Корректность копирования сложного CFG с ветвлениями внутри callee. |
| `skip-with-args.ll` | Проверка игнорирования функций, принимающих аргументы. |
| `skip-non-void.ll` | Проверка игнорирования функций с возвращаемым значением (не void). |
| `skip-declaration.ll` | Проверка игнорирования внешних функций (declarations) без тела. |

<img width="1185" height="392" alt="image" src="https://github.com/user-attachments/assets/036fea91-648f-4f1f-994b-72c0ea255195" />
